### PR TITLE
Cache cibuildwheel interpreters across CI runs

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -105,9 +105,16 @@ jobs:
         with:
           version: "latest"
 
+      - name: Cache cibuildwheel interpreters
+        uses: actions/cache@v5
+        with:
+          path: ${{ github.workspace }}/.cibw-cache
+          key: cibw-${{ matrix.id }}-${{ hashFiles('.github/workflows/wheels.yml') }}
+
       - name: Build and Test Wheels
         uses: pypa/cibuildwheel@v3.4.1
         env:
+          CIBW_CACHE_PATH: ${{ github.workspace }}/.cibw-cache
           CIBW_BUILD: ${{ matrix.pybuilds }}
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}


### PR DESCRIPTION
Persist CIBW_CACHE_PATH with actions/cache so the per-version CPython downloads (NuGet on Windows, python.org installers on macOS) are reused between runs instead of re-fetched every build.