### PR TITLE
Stop ignoring actions/* in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,6 @@ updates:
         applies-to: version-updates
         patterns:
           - "*"
-    ignore:
-      # Optional: Official actions have moving tags like v1;
-      # if you use those, you don't need updates.
-      - dependency-name: "actions/*"
 
   - package-ecosystem: "uv"
     directory: "/"


### PR DESCRIPTION
The ignore rule suppressed all updates for GitHub-owned actions on the assumption that moving major tags suffice. Moving tags only track within a major, so cross-major bumps (e.g. the Node 20 -> 24 runtime change in actions/cache v5) were never proposed. Removing it lets dependabot raise those, grouped under the existing github-actions group.